### PR TITLE
Modified the (Main, VPC-Production and VPC-Management) templates to o…

### DIFF
--- a/templates/main.template
+++ b/templates/main.template
@@ -408,10 +408,14 @@ Resources:
           !GetAtt
           - ProductionVpcTemplate
           - Outputs.rVPCProduction
-        pRouteTableProdPrivate:
+        pRouteTableProdPrivateA:
           !GetAtt
           - ProductionVpcTemplate
-          - Outputs.rRouteTableProdPrivate
+          - Outputs.rRouteTableProdPrivateA
+        pRouteTableProdPrivateB:
+          !GetAtt
+          - ProductionVpcTemplate
+          - Outputs.rRouteTableProdPrivateB
         pRouteTableProdPublic:
           !GetAtt
           - ProductionVpcTemplate


### PR DESCRIPTION
Modified templates (Main, VPC-Production and VPC-Management)
 to output both the PrivateA and PriavateB routing tables. 
 Needed for creating the correct peering connections to allow
 both Production subnets in both AZ's (Private A and Private B)
 to be accessible from the Management plane (Mgmt VPC)